### PR TITLE
Add custom log method

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -114,10 +114,15 @@ GrayGelf.prototype._compress = function (gelf, next) {
   }.bind(this))
 }
 
+GrayGelf.prototype.log = function (level, msg, addn) {
+  var gelf = this._prepJson(level, msg, addn)
+
+  this._compress(gelf, this.write)
+}
+
 LOG_LEVELS.forEach(function (name, level) {
   GrayGelf.prototype[name] = function (msg, addn) {
-    var gelf = this._prepJson(level, msg, addn)
-    this._compress(gelf, this.write)
+    this.log(level, msg, addn)
   }
 })
 

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,7 @@ logger.on('error', console.error) // is an EventEmitter
 
 logger.info('Howdy GrayLog')
 logger.error('oh no', new Error('bad news'))
+logger.log('emerg', 'noes')
 ```
 
 ### Available Options
@@ -46,6 +47,9 @@ logger.warn(...)   // 4
 logger.notice(...) // 5
 logger.info(...)   // 6
 logger.debug(...)  // 7
+
+// or manually
+logger.log(level, short, full)
 ```
 
 Each logger function takes two parameters which can be of any type but typically `(string, object)`.

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -43,6 +43,10 @@ suite('level setups', function () {
     })
   })
 
+  test('sets up method for custom level logging', function () {
+    assert.ok(typeof gg.log === 'function')
+  })
+
   test('sets up streams for every syslog level', function () {
     LOG_LEVELS.forEach(function (level) {
       assert.strictEqual(gg.stream[level].writable, true, level+' should be writable')


### PR DESCRIPTION
#### Changes
- `_prepJson` accepts the level as a string
- added .log method, where the level is passed as a parameter
#### Use case

I'm writing a [winston](https://github.com/flatiron/winston) graylog2 transport, and I'm using graygelf to talk to graylog. Instead of picking the appropriate graygelf method `.emerg`, `.error`, etc, it would be cleaner if graygelf had a `.log` method which also accepts the level.
