### PR TITLE
do not get the hostname for every message

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -14,6 +14,7 @@ var GrayGelf = function (opts) {
   this.facility = opts.facility || 'GELF'
   this.chunkSize = opts.chunkSize || GrayGelf.CHUNK_WAN
   this.compressType = (opts.compressType || '') === 'gzip' ? 'gzip' : 'deflate'
+  this.hostname = os.hostname()
   this._udp = dgram.createSocket('udp4')
   this._udp.on('error', this._checkError.bind(this))
 
@@ -47,7 +48,7 @@ GrayGelf.prototype._prepJson = function (level, short, full) {
 
   var gelf = {
     version: '1.0',
-    host: os.hostname(),
+    host: this.hostname,
     short_message: Buffer.isBuffer(short) ? short.toString() : short,
     timestamp: Date.now() / 1000 >> 0,
     level: level,


### PR DESCRIPTION
`os.hostname()` will [uname](http://linux.die.net/man/2/uname) every time on linux. ([proof](https://gist.github.com/danmilon/4989367))

We better get it once and call it a day.
