### PR TITLE
Fixes #12 Increase to millisecond precision in timestamp fallback function

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ var split  = require('split')
  */
 var timestamp
 try       { timestamp = require('microtime').nowDouble }
-catch (e) { timestamp = function () { return Date.now() / 1000 >> 0 } }
+catch (e) { timestamp = function () { return Date.now() / 1000.0 } }
 
 /**
  * Available logging levels


### PR DESCRIPTION
Here's the fix. I wasn't able to run the test suite locally due to some issue with tape in windows environments, but i've had a look through the suite and can't see anything this would affect.

We've tested this fix in runtime in both windows and aws lambda (linux) environments.

Let me know if you like any additional comments or tests around this.