### PR TITLE
Added support for non-compressed GELF messages in client and server

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,6 +117,12 @@ GrayGelf.prototype._send = function (gelf) {
   var gelfbuf = new Buffer(JSON.stringify(gelf))
   var graygelf = this
 
+  if (gelfbuf.length < graygelf.chunkSize) {
+    // The buffer fits within the nominal chunksize,
+    // so compression can be bypassed and sent directly
+    return graygelf.write(gelfbuf)
+  }
+
   zlib[this.compressType](gelfbuf, function (er, message) {
     /* istanbul ignore if */
     if (er) return graygelf.emit('error', er)

--- a/server.js
+++ b/server.js
@@ -80,6 +80,9 @@ GrayGelfServer.prototype._message = function (buf, details) {
     case 0x1e: // chunked message
       this._handleChunk(buf)
       break
+    case 0x7b: // json message (not compressed)
+      this._broadcast(null, buf)
+      break;
     default:   // unknown message
   }
 }


### PR DESCRIPTION
- (Client) Added direct send of a gelf message if it fits within a single chunk.
- (Server) Added handler for non-compressed JSON.
- (Tests) Updated tests for both client and server to exercise the previous deflate path and the new non-compressed JSON paths.