### PR TITLE
add option to always compress messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ var GrayGelf = function(opts) {
 
   this.chunkSize = opts.chunkSize || GrayGelf.CHUNK_WAN
   this.compressType = (opts.compressType || '') === 'gzip' ? 'gzip' : 'deflate'
+  this.alwaysCompress = opts.alwaysCompress || false
   this.hostname = os.hostname()
 
   if (!opts.mock) {
@@ -117,7 +118,7 @@ GrayGelf.prototype._send = function(gelf) {
   var gelfbuf = new Buffer(JSON.stringify(gelf))
   var graygelf = this
 
-  if (gelfbuf.length < graygelf.chunkSize) {
+  if (gelfbuf.length < graygelf.chunkSize && !graygelf.alwaysCompress) {
     // The buffer fits within the nominal chunksize,
     // so compression can be bypassed and sent directly
     return graygelf.write(gelfbuf)

--- a/readme.md
+++ b/readme.md
@@ -83,6 +83,8 @@ chunkSize
   - size of chunked messages in bytes (default: 1240)
 compressType
   - compression 'gzip' or 'deflate' (default: 'deflate')
+alwaysCompress
+  - whether to always compress or go by chunkSize (default: false)
 mock
   - don't send messages to GrayLog2 (default: false)
 ```


### PR DESCRIPTION
Issue: My company's gelf server ignores non-gzip messages entirely, and short messages were (confusingly) dropped. We needed option to compress regardless of size threshold.

Add an option (default false) to always send compressed messages.